### PR TITLE
Update the link to tutorial docs in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # arlas_playground
 
-Open the [ARLAS Playground Tutorials documentation](https://gisaia.github.io/arlas_playground/).
+Open the [ARLAS Playground Tutorials documentation](https://docs.arlas.io/external_docs/arlas_playground/).


### PR DESCRIPTION
Change:
- Update the link to docs.arlas.io tutorial docs in readme